### PR TITLE
[회원] 도메인 정의및 회원가입 API 

### DIFF
--- a/api/src/main/java/net/openu/api/v1/account/AccountController.java
+++ b/api/src/main/java/net/openu/api/v1/account/AccountController.java
@@ -1,6 +1,7 @@
 package net.openu.api.v1.account;
 
-import net.openu.core.domain.account.Account;
+import lombok.RequiredArgsConstructor;
+import net.openu.service.AccountService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,11 +15,16 @@ import org.springframework.web.bind.annotation.RestController;
  */
 
 @RestController
+@RequestMapping(value = {"/api/accounts", "/api/v1/accounts"})
+
+@RequiredArgsConstructor
 public class AccountController {
+
+  private final AccountService accountService;
 
   @RequestMapping(method = RequestMethod.POST)
   @ResponseStatus(value = HttpStatus.CREATED)
   public AccountDto.Response signUp(@RequestBody final AccountDto.SignUpReq request) {
-    return AccountDto.Response.of(null);
+    return AccountDto.Response.of(accountService.create(request));
   }
 }

--- a/api/src/main/java/net/openu/api/v1/account/AccountController.java
+++ b/api/src/main/java/net/openu/api/v1/account/AccountController.java
@@ -1,0 +1,24 @@
+package net.openu.api.v1.account;
+
+import net.openu.core.domain.account.Account;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Created by iopenu@gmail.com on 2020/05/03
+ * Github : https://github.com/bnbaek
+ */
+
+@RestController
+public class AccountController {
+
+  @RequestMapping(method = RequestMethod.POST)
+  @ResponseStatus(value = HttpStatus.CREATED)
+  public AccountDto.Response signUp(@RequestBody final AccountDto.SignUpReq request) {
+    return AccountDto.Response.of(null);
+  }
+}

--- a/api/src/main/java/net/openu/api/v1/account/AccountDto.java
+++ b/api/src/main/java/net/openu/api/v1/account/AccountDto.java
@@ -1,0 +1,77 @@
+package net.openu.api.v1.account;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import net.openu.core.domain.account.Account;
+
+/**
+ * Created by iopenu@gmail.com on 2020/05/03
+ * Github : https://github.com/bnbaek
+ */
+public class AccountDto {
+
+  @Getter
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  public static class SignUpReq {
+
+    private String email;
+    private String firstName;
+    private String lastName;
+    private String password;
+    private String address1;
+    private String address2;
+    private String zipCode;
+
+    @Builder
+    public SignUpReq(String email, String firstName, String lastName, String password, String address1, String address2,
+        String zipCode) {
+      this.email = email;
+      this.firstName = firstName;
+      this.lastName = lastName;
+      this.password = password;
+      this.address1 = address1;
+      this.address2 = address2;
+      this.zipCode = zipCode;
+    }
+
+    public Account toEntity() {
+      return Account.builder()
+          .email(this.email)
+          .firstName(this.firstName)
+          .lastName(this.lastName)
+          .password(this.password)
+          .address1(this.address1)
+          .address2(this.address2)
+          .zipCode(this.zipCode)
+          .build();
+    }
+  }
+
+  @Getter
+  public static class Response {
+
+    private String email;
+    private String firstName;
+    private String lastName;
+    private String address1;
+    private String address2;
+    private String zipCode;
+
+    public Response(Account account) {
+      this.email = account.getEmail();
+      this.firstName = account.getFirstName();
+      this.lastName = account.getLastName();
+      this.address1 = account.getAddress1();
+      this.address2 = account.getAddress2();
+      this.zipCode = account.getZipCode();
+
+    }
+
+    public static Response of(Account account) {
+      return new Response(account);
+
+    }
+  }
+}

--- a/api/src/main/java/net/openu/service/AccountService.java
+++ b/api/src/main/java/net/openu/service/AccountService.java
@@ -1,0 +1,26 @@
+package net.openu.service;
+
+import lombok.RequiredArgsConstructor;
+import net.openu.api.v1.account.AccountDto;
+import net.openu.core.domain.account.Account;
+import net.openu.core.domain.account.AccountRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Created by iopenu@gmail.com on 2020/05/03
+ * Github : https://github.com/bnbaek
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AccountService {
+
+  private final AccountRepository accountRepository;
+
+  @Transactional
+  public Account create(AccountDto.SignUpReq request) {
+    return accountRepository.save(request.toEntity());
+  }
+
+}

--- a/api/src/test/java/net/openu/api/v1/account/AccountControllerTest.java
+++ b/api/src/test/java/net/openu/api/v1/account/AccountControllerTest.java
@@ -1,0 +1,93 @@
+package net.openu.api.v1.account;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.openu.api.v1.account.AccountDto.SignUpReq;
+import net.openu.service.AccountService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+
+/**
+ * Created by iopenu@gmail.com on 2020/05/03
+ * Github : https://github.com/bnbaek
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AccountControllerTest {
+
+  @InjectMocks
+  private AccountController accountController;
+
+  @Mock
+  private AccountService accountService;
+
+  private ObjectMapper objectMapper = new ObjectMapper();
+
+  private MockMvc mockMvc;
+
+
+  @Before
+  public void setUp() throws Exception {
+    mockMvc = MockMvcBuilders.standaloneSetup(accountController)
+        .addFilters(new CharacterEncodingFilter("UTF-8", true))  // 필터 추가
+        .alwaysDo(print())
+        .build();
+
+  }
+
+  @Test
+  public void signUp() throws Exception {
+    //given
+    final AccountDto.SignUpReq request = buildSignUpRequest();
+    given(accountService.create(any())).willReturn(request.toEntity());
+    //when
+    final ResultActions resultActions = requestSignUp(request);
+    //then
+    resultActions
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.address1", is(request.getAddress1())))
+        .andExpect(jsonPath("$.address2", is(request.getAddress2())))
+        .andExpect(jsonPath("$.zipCode", is(request.getZipCode())))
+        .andExpect(jsonPath("$.email", is(request.getEmail())))
+        .andExpect(jsonPath("$.firstName", is(request.getFirstName())))
+        .andExpect(jsonPath("$.lastName", is(request.getLastName())))
+    ;
+
+  }
+
+  private ResultActions requestSignUp(SignUpReq request) throws Exception {
+    return mockMvc.perform(post("/api/accounts")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(request)))
+        .andDo(print());
+  }
+
+  private SignUpReq buildSignUpRequest() {
+    return AccountDto.SignUpReq.builder()
+        .email("email")
+        .password("비밀번호")
+        .firstName("이름")
+        .lastName("성")
+        .address1("주소1")
+        .address2("주소2")
+        .zipCode("우편번호")
+        .build();
+  }
+
+}

--- a/core/src/main/java/net/openu/core/domain/account/Account.java
+++ b/core/src/main/java/net/openu/core/domain/account/Account.java
@@ -8,6 +8,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -42,6 +43,7 @@ public class Account {
   @Column(name = "updated_at")
   private LocalDateTime updatedAt;
 
+  @Builder
   public Account(Long id, String email, String firstName, String lastName, String password, String address1, String address2,
       String zipCode) {
     this.id = id;
@@ -55,8 +57,6 @@ public class Account {
     this.createdAt = LocalDateTime.now();
     this.updatedAt = LocalDateTime.now();
   }
-
-//  public void updateAddress()
 
 
 }

--- a/core/src/main/java/net/openu/core/domain/account/Account.java
+++ b/core/src/main/java/net/openu/core/domain/account/Account.java
@@ -1,0 +1,62 @@
+package net.openu.core.domain.account;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "account")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Account {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "account_id", updatable = false, unique = true)
+  private Long id;
+
+  @Column(name = "email", nullable = false, unique = true)
+  private String email;
+  @Column(name = "first_name", nullable = false)
+  private String firstName;
+  @Column(name = "last_name", nullable = false)
+  private String lastName;
+  @Column(name = "password", nullable = false)
+  private String password;
+  @Column(name = "address1", nullable = false)
+  private String address1;
+  @Column(name = "address2", nullable = false)
+  private String address2;
+  @Column(name = "zip_code", nullable = false)
+  private String zipCode;
+
+  @Column(name = "created_at")
+  private LocalDateTime createdAt;
+  @Column(name = "updated_at")
+  private LocalDateTime updatedAt;
+
+  public Account(Long id, String email, String firstName, String lastName, String password, String address1, String address2,
+      String zipCode) {
+    this.id = id;
+    this.email = email;
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.password = password;
+    this.address1 = address1;
+    this.address2 = address2;
+    this.zipCode = zipCode;
+    this.createdAt = LocalDateTime.now();
+    this.updatedAt = LocalDateTime.now();
+  }
+
+//  public void updateAddress()
+
+
+}

--- a/core/src/main/java/net/openu/core/domain/account/AccountRepository.java
+++ b/core/src/main/java/net/openu/core/domain/account/AccountRepository.java
@@ -1,0 +1,11 @@
+package net.openu.core.domain.account;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Created by iopenu@gmail.com on 2020/05/03
+ * Github : https://github.com/bnbaek
+ */
+public interface AccountRepository extends JpaRepository<Account, Long> {
+
+}


### PR DESCRIPTION
## Issue #1 
* 회원관리 도메인 정의
* 회원가입 api 작성
* 회원가입 test code
* Close #1  


## Summary
*  회원관련 도메인을 정의하고 회원가입 api를 작성한다.

## Commit Log
* 1bf47854b457ddef0afad57c8d5b5f9567bc6826  [DOMAIN] ACCOUNT ADD
* 005f631325091f370c512e2f34fb7e37ef1209a8  [API] account siginup add
* 5c16523206143deba349063ec3d1b6b6ff25e914 [Repository] AccountRepository add
*  de28627e66a03c205169f4820ef42a7eea7a34a4  [Service]account service add
* 44a778c3334a2b614a8e8d2fefd9583fc120dae5  [API-test] account signup add


